### PR TITLE
tweaked approach to incident subjects

### DIFF
--- a/bin/report
+++ b/bin/report
@@ -27,7 +27,7 @@ incidents.each do |i|
   # normalize instance-type-id/Service
   k = ((i["trigger_summary_data"] && i["trigger_summary_data"]["subject"]) || i["incident_key"]).
         gsub(/^([a-z-]+)-([0-9]+)\/([^:]+)/, "\\1-XXXXX/\\3").
-        trunc(120)
+        trunc(90)
   subjects[k] ||= 0
   subjects[k]  += 1
 

--- a/bin/report
+++ b/bin/report
@@ -25,7 +25,9 @@ days      = Hash[%w(Mon Tue Wed Thu Fri Sat Sun ).zip [0]*7]
 
 incidents.each do |i|
   # normalize instance-type-id/Service
-  k = i["incident_key"].gsub(/^([a-z-]+)-([0-9]+)\/([^:]+)/, "\\1-XXXXX/\\3")
+  k = ((i["trigger_summary_data"] && i["trigger_summary_data"]["subject"]) || i["incident_key"]).
+        gsub(/^([a-z-]+)-([0-9]+)\/([^:]+)/, "\\1-XXXXX/\\3").
+        trunc(120)
   subjects[k] ||= 0
   subjects[k]  += 1
 

--- a/lib/off-call.rb
+++ b/lib/off-call.rb
@@ -27,6 +27,14 @@ class String
   def to_time
     Time.parse(self) rescue Chronic.parse(self)
   end
+
+  def trunc(len)
+    if (self.length > len)
+      self[0...len-3] + "..."
+    else
+      self
+    end
+  end
 end
 
 class Hash


### PR DESCRIPTION
It looks like different types of incidents have slightly different schemas with respect to incident keys & subject titles. Some have good `incident_key` (e.g. API-triggered incidents), others have an `incident_key` but it doesn't seem to be useful (e.g. email-triggered incident `incident_key`s just say "triggered by email"), and others don't have them at all (e.g. manually opened incidents). This patch attempts to choose the right name for incidents given these differing schemas.

I didn't dig into the API to much, so there may well be better ways to approach this.

Also, adds truncation of incident titles to prevent huge tables, especially from incidents that have SQL queries in them.
